### PR TITLE
イベント自体のステータスを表示させる

### DIFF
--- a/app/templates/event/event_list.html
+++ b/app/templates/event/event_list.html
@@ -19,19 +19,26 @@
                 {{ event.get_status.msg }}
               </span>
             {% else %}
-              {% if event in user.participating_event.all %}
-                {% for participation in user.participation_set.all %}
-                  {% if participation.event == event %}
-                    <span class="label label-warning" style="margin-right: 1em;">
-                      {{ participation.status }}
-                    </span>
-                  {% endif %}
-                {% endfor %}
-              {% else %}
-                <span class="label label-info" style="margin-right: 1em;">
-                  {{ event.get_status.msg }}
-                </span>
-              {% endif %}
+              <span class="label label-info" style="margin-right: 1em;">
+                {{ event.get_status.msg }}
+              </span>
+
+              {% comment %}
+                {% if event in user.participating_event.all %}
+                  {% for participation in user.participation_set.all %}
+                    {% if participation.event == event %}
+                      <span class="label label-warning" style="margin-right: 1em;">
+                        {{ participation.status }}
+                      </span>
+                    {% endif %}
+                  {% endfor %}
+                {% else %}
+                  <span class="label label-info" style="margin-right: 1em;">
+                    {{ event.get_status.msg }}
+                  </span>
+                {% endif %}
+              {% endcomment %}
+              
             {% endif %}
             <i class="fa fa-calendar" aria-hidden="true"></i>
             {{event.start_time_format | date:'n/j (D)' }}


### PR DESCRIPTION
イベントは参加者のステータスを表示している。参加者のステータスは現在のコードではハードコードで日本語（DB内データ含め）。
イベント自体のステータスを表示させることで回避。
参加者ステータスの言語問題は今の所影響なしのよう。

issue: https://github.com/internship2016/sovolo/issues/304