### PR TITLE
Facebook連携のAPI実行パラメーターから年齢を外す

### DIFF
--- a/app/sovolo/settings.py
+++ b/app/sovolo/settings.py
@@ -201,7 +201,7 @@ SOCIAL_AUTH_FACEBOOK_SECRET = os.environ.get('SOCIAL_AUTH_FACEBOOK_SECRET')
 SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
 SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
     'locale': 'ja_JP',
-    'fields': 'id, name, email, age_range'
+    'fields': 'id, name, email'
 }
 
 EMAIL_BACKEND = os.environ.get('EMAIL_BACKEND',


### PR DESCRIPTION
settingsファイルからage_rangeを指定フィールドから外しました。
Twitterは使ってないらしいです。
